### PR TITLE
Load the yardstick docker image on jump host

### DIFF
--- a/roles/compass/tasks/main.yml
+++ b/roles/compass/tasks/main.yml
@@ -33,6 +33,10 @@
     - "{{ compass_db }}"
     - "{{ compass_mq }}"
 
+- name: load yardstick image
+  shell: |
+    docker load -i "{{ compass_dists_dir }}/yardstick.tar"
+
 - name: copy files
   shell:
     cp -rf "{{ item }}" "{{ docker_compose_dir }}"


### PR DESCRIPTION
This patch during deployment loads the yardstick image from
the tar file.

Signed-off-by: Manjunath Ranganathaiah <manjunath.ranganathaiah@intel.com>