### PR TITLE
MySQL does not start with overlay2 and overlay

### DIFF
--- a/roles/compass/templates/docker-compose.yml.j2
+++ b/roles/compass/templates/docker-compose.yml.j2
@@ -10,6 +10,8 @@ services:
     tty: true
     image: {{ compass_db }}
     stdin_open: true
+    volumes:
+    - /var/lib/mysql
     command:
     - /sbin/entrypoint.sh
 


### PR DESCRIPTION
compass-db cannot startup, due to

> 170801 15:19:28 [Note] Server socket created on IP: '127.0.0.1'.
170801 15:19:28 [ERROR] Fatal error: Can't open and lock privilege tables: Got error 140 from storage engine

xref docker/for-linux#72